### PR TITLE
Fixed blank space in mobile view

### DIFF
--- a/frontend/src/App.css
+++ b/frontend/src/App.css
@@ -73,6 +73,9 @@ footer {
   .App {
     background-image: url(./background-resp.svg);
     background-size: cover;
+    position: fixed;
+    height: 93vh;
+    width: 100vw;
   }
 
   .hitec-logo {


### PR DESCRIPTION
Closes #38 

### Causes:
Mobile browsers have a search bar on top of the screen, which is calculated for the viewport metrics, using 100vh works on desktop, but not on mobile browsers due to this. A workaround is to use `position: fixed` which is the setting used here.

Learn more in [this link](https://stackoverflow.com/questions/37112218/css3-100vh-not-constant-in-mobile-browser)