### PR TITLE
Revert "Fixed blank space in mobile view"

### DIFF
--- a/frontend/src/App.css
+++ b/frontend/src/App.css
@@ -73,9 +73,6 @@ footer {
   .App {
     background-image: url(./background-resp.svg);
     background-size: cover;
-    position: fixed;
-    height: 93vh;
-    width: 100vw;
   }
 
   .hitec-logo {


### PR DESCRIPTION
Reverts TECoding/hitec-2021#45

The branch was not ready for production, iOS devices were not tested.
Found critical error that involves navigation.